### PR TITLE
fix config schema for BUSY pin to match input-only pins

### DIFF
--- a/components/qalcosonicnfc/__init__.py
+++ b/components/qalcosonicnfc/__init__.py
@@ -84,7 +84,7 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_PN5180_MISO_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_PN5180_SCK_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_PN5180_NSS_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_PN5180_BUSY_PIN): pins.gpio_output_pin_schema,
+            cv.Required(CONF_PN5180_BUSY_PIN): pins.gpio_input_pin_schema,
             cv.Required(CONF_PN5180_RST_PIN): pins.gpio_output_pin_schema
         }
     )


### PR DESCRIPTION
The busy pin is only used as an input. In the config-schema, it was defined as an output pin. This prohibited the use of esp32 pins 34,35,36 or 39 as a busy pin, because these are input-only pins.