### PR TITLE
Fix ESPHome 2026.6 deprecations

### DIFF
--- a/components/qalcosonicnfc/qalcosonicnfc.cpp
+++ b/components/qalcosonicnfc/qalcosonicnfc.cpp
@@ -157,7 +157,7 @@ void QalcosonicNfc::setup() {
     
     this->nfc_->begin();
     if (!this->nfc_->reset()) {
-        mark_failed("No communication to PN5180");
+        mark_failed(LOG_STR("No communication to PN5180"));
         return;
     }
     
@@ -169,7 +169,7 @@ void QalcosonicNfc::setup() {
         ESP_LOGE(TAG, "Initialization failed! Marking as failed");
         //delay(1000);
         //esp_restart();
-        mark_failed("Incorrect PN5180 product version");
+        mark_failed(LOG_STR("Incorrect PN5180 product version"));
     }
     
     uint8_t firmwareVersion[2];


### PR DESCRIPTION
Thank you for this awesome project!

This change/PR will fix the following warnings that appear during the compilation in ESPHome:

```
src/esphome/components/qalcosonicnfc/qalcosonicnfc.cpp: In member function 'virtual void esphome::qalcosonicnfc::QalcosonicNfc::setup()':
src/esphome/components/qalcosonicnfc/qalcosonicnfc.cpp:160:20: warning: 'void esphome::Component::mark_failed(const char*)' is deprecated: Use mark_failed(LOG_STR("static string literal")) instead. Do NOT use .c_str() from temporary strings. Will stop working in 2026.6.0 [-Wdeprecated-declarations]
  160 |         mark_failed("No communication to PN5180");
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/esphome/components/qalcosonicnfc/qalcosonicnfc.h:21,
                 from src/esphome/components/qalcosonicnfc/qalcosonicnfc.cpp:21:
src/esphome/core/component.h:174:8: note: declared here
  174 |   void mark_failed(const char *message) {
      |        ^~~~~~~~~~~
src/esphome/components/qalcosonicnfc/qalcosonicnfc.cpp:172:20: warning: 'void esphome::Component::mark_failed(const char*)' is deprecated: Use mark_failed(LOG_STR("static string literal")) instead. Do NOT use .c_str() from temporary strings. Will stop working in 2026.6.0 [-Wdeprecated-declarations]
  172 |         mark_failed("Incorrect PN5180 product version");
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/core/component.h:174:8: note: declared here
  174 |   void mark_failed(const char *message) {
      |        ^~~~~~~~~~~
```

Needs to be fixed as the deprecated call will be removed in ESPHome 2026.6.0.