### PR TITLE
Fix "took a long time" warnings by feeding watchdog during NFC readout

### DIFF
--- a/components/qalcosonicnfc/qalcosonicnfc.cpp
+++ b/components/qalcosonicnfc/qalcosonicnfc.cpp
@@ -18,6 +18,7 @@
 //
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include "qalcosonicnfc.h"
 #include "PN5180ISO15693.h"
 #include "PN5180Debug.h"
@@ -212,6 +213,7 @@ void QalcosonicNfc::update() {
       this->status_clear_error();
   }
   
+  App.feed_wdt();
   ESP_LOGI(TAG, "Scanning for water meter...");
   ISO15693ErrorCode rc = this->nfc_->getInventory(this->meterUid);
   if (ISO15693_EC_OK != rc) {
@@ -238,6 +240,7 @@ void QalcosonicNfc::update() {
   }
   ESP_LOGD(TAG, "ST25: Energy harvesting state: EH_EN=%u, EH_ON=%u, FIELD_ON=%u, VCC_ON=%u", this->readBuffer[1] & ST25_EH_EN, (this->readBuffer[1] & ST25_EH_ON) >> 1, (readBuffer[1] & ST25_FIELD_ON) >> 2, (this->readBuffer[1] & ST25_VCC_ON) >> 3);
   
+  App.feed_wdt();
   if(!this->st25MailboxEnable()) {
       this->nfc_->setRF_off();
       return;
@@ -248,10 +251,12 @@ void QalcosonicNfc::update() {
    uint8_t commandResetApp[] = {0x10, 0x40, 0xFE};
    uint8_t commandGetData1[] = {0x10, 0x7B, 0xFE};
    
+   App.feed_wdt();
    if(!issueMeterCommand(commandResetApp, sizeof(commandResetApp)/sizeof(commandResetApp[0]))) {
       this->nfc_->setRF_off();
       return;
     }
+   App.feed_wdt();
    if(!issueMeterCommand(commandGetData1, sizeof(commandGetData1)/sizeof(commandGetData1[0]))) {
       this->nfc_->setRF_off();
       return;


### PR DESCRIPTION
The ESPHome watchdog was logging warnings every readout cycle because the NFC communication blocks for ~800ms:

```
[08:29:19.149][W][component:579]: qalcosonicnfc took a long time for an operation (795 ms)
[08:29:19.149][W][component:582]: Components should block for at most 30 ms
[08:29:19.149][W][component:579]: api took a long time for an operation (800 ms)
[08:29:19.149][W][component:582]: Components should block for at most 30 ms
```

This gets fixed by calling `App.feed_wdt()` before each major NFC operation in `update()`. The ~800ms duration is unchanged, the hardware just needs that time. But the watchdog no longer complains about it.

Note: the `api` component will still log the same warning since it also gets delayed by the blocking NFC communication. This is cosmetic, Home Assistant stays connected and sensors update correctly. Fixing it properly would require a full async refactor of the NFC communication, which is out of scope here.
