### PR TITLE
Add consecutive errors sensor and configurable error limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,13 @@ qalcosonicnfc:
   raw_data_sensor:
     name: "M-BUS Rohdaten"
     disabled_by_default: True
-  # Binary sensor that indicates whether the last readout attempt succeeded (true) or failed (false).
-  # Use this sensor to get immediate feedback of a readout error even if consecutive_errors_limit is
-  # larger than 0 and the main sensors are not yet marked as unavailable.
-  readout_success_sensor:
-    name: "Readout Success"
+  # Sensor that indicates how many consecutive readout attempts have failed.
+  # It will be 0 on a successful readout and increment on each failure.
+  # Note: This value can exceed the consecutive_errors_limit, as the limit
+  # only defines when the main sensors are set to unavailable (NAN).
+  consecutive_errors_sensor:
+    name: "Consecutive Errors"
+    disabled_by_default: True
 
 # Enable logging
 logger:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ qalcosonicnfc:
   update_interval: 300s # How often should the component query the water meter for a value.
                         # Battery drain:
                         # 60s: ~ 1% per 75 days (added 10.02.2026, tested by dbmaxpayne)
+  consecutive_errors_limit: 5 # Optional. Default: 5. How many consecutive failed readout
+                              # attempts are allowed before sensors are set to unavailable (NAN).
+                              # Set to 0 to never set sensors to unavailable.
   pn5180_mosi_pin: GPIO23
   pn5180_miso_pin: GPIO19
   pn5180_sck_pin:  GPIO18
@@ -90,6 +93,11 @@ qalcosonicnfc:
   raw_data_sensor:
     name: "M-BUS Rohdaten"
     disabled_by_default: True
+  # Binary sensor that indicates whether the last readout attempt succeeded (true) or failed (false).
+  # Use this sensor to get immediate feedback of a readout error even if consecutive_errors_limit is
+  # larger than 0 and the main sensors are not yet marked as unavailable.
+  readout_success_sensor:
+    name: "Readout Success"
 
 # Enable logging
 logger:

--- a/components/qalcosonicnfc/__init__.py
+++ b/components/qalcosonicnfc/__init__.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import sensor, text_sensor#, spi
-from esphome.const import CONF_ID, CONF_NAME, CONF_PROTOCOL, CONF_UPDATE_INTERVAL, UNIT_CUBIC_METER, UNIT_CUBIC_METER_PER_HOUR, UNIT_CELSIUS, UNIT_PERCENT, ICON_WATER, ICON_THERMOMETER, ICON_BATTERY, STATE_CLASS_TOTAL_INCREASING, STATE_CLASS_MEASUREMENT, DEVICE_CLASS_WATER, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_BATTERY
+from esphome.const import CONF_ID, CONF_NAME, CONF_PROTOCOL, CONF_UPDATE_INTERVAL, UNIT_CUBIC_METER, UNIT_CUBIC_METER_PER_HOUR, UNIT_CELSIUS, UNIT_PERCENT, ICON_WATER, ICON_THERMOMETER, ICON_BATTERY, STATE_CLASS_TOTAL_INCREASING, STATE_CLASS_MEASUREMENT, DEVICE_CLASS_WATER, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_BATTERY, ENTITY_CATEGORY_DIAGNOSTIC
 
 CODEOWNERS = ["@dbmaxpayne"]
 
@@ -83,8 +83,10 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_RAW_DATA_SENSOR, default={ CONF_NAME: "Raw M-BUS Data",}): text_sensor.text_sensor_schema(),
             cv.Optional(CONF_TIMEPOINT_SENSOR, default={ CONF_NAME: "Timepoint",}): text_sensor.text_sensor_schema(),
             cv.Optional(CONF_CONSECUTIVE_ERRORS_SENSOR, default={ CONF_NAME: "Consecutive Errors",}): sensor.sensor_schema(
+                icon="mdi:alert-circle",
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_CONSECUTIVE_ERRORS_LIMIT, default=5): cv.uint8_t,
             cv.Required(CONF_PN5180_MOSI_PIN): pins.gpio_output_pin_schema,

--- a/components/qalcosonicnfc/__init__.py
+++ b/components/qalcosonicnfc/__init__.py
@@ -1,12 +1,12 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
-from esphome.components import sensor, text_sensor, binary_sensor#, spi
+from esphome.components import sensor, text_sensor#, spi
 from esphome.const import CONF_ID, CONF_NAME, CONF_PROTOCOL, CONF_UPDATE_INTERVAL, UNIT_CUBIC_METER, UNIT_CUBIC_METER_PER_HOUR, UNIT_CELSIUS, UNIT_PERCENT, ICON_WATER, ICON_THERMOMETER, ICON_BATTERY, STATE_CLASS_TOTAL_INCREASING, STATE_CLASS_MEASUREMENT, DEVICE_CLASS_WATER, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_BATTERY
 
 CODEOWNERS = ["@dbmaxpayne"]
 
-AUTO_LOAD = ["sensor", "text_sensor", "binary_sensor", "spi"]
+AUTO_LOAD = ["sensor", "text_sensor", "spi"]
 
 DEPENDENCIES = ["network"]
 
@@ -28,7 +28,7 @@ CONF_EXTERNAL_TEMPERATURE_SENSOR = "external_temperature_sensor"
 CONF_BATTERY_LEVEL_SENSOR = "battery_level_sensor"
 CONF_TIMEPOINT_SENSOR = "timepoint_sensor"
 CONF_RAW_DATA_SENSOR = "raw_data_sensor"
-CONF_READOUT_SUCCESS_SENSOR = "readout_success_sensor"
+CONF_CONSECUTIVE_ERRORS_SENSOR = "consecutive_errors_sensor"
 CONF_CONSECUTIVE_ERRORS_LIMIT = "consecutive_errors_limit"
 
 qalcosonicnfc_ns = cg.esphome_ns.namespace("qalcosonicnfc")
@@ -82,7 +82,10 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_BATTERY,),
             cv.Optional(CONF_RAW_DATA_SENSOR, default={ CONF_NAME: "Raw M-BUS Data",}): text_sensor.text_sensor_schema(),
             cv.Optional(CONF_TIMEPOINT_SENSOR, default={ CONF_NAME: "Timepoint",}): text_sensor.text_sensor_schema(),
-            cv.Optional(CONF_READOUT_SUCCESS_SENSOR, default={ CONF_NAME: "Readout Success",}): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_CONSECUTIVE_ERRORS_SENSOR, default={ CONF_NAME: "Consecutive Errors",}): sensor.sensor_schema(
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend({cv.Optional("disabled_by_default", default=True): cv.boolean}),
             cv.Optional(CONF_CONSECUTIVE_ERRORS_LIMIT, default=5): cv.uint8_t,
             cv.Required(CONF_PN5180_MOSI_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_PN5180_MISO_PIN): pins.gpio_output_pin_schema,
@@ -133,7 +136,7 @@ async def to_code(config):
     raw_data_sensor = await text_sensor.new_text_sensor(config.get(CONF_RAW_DATA_SENSOR))
     cg.add(var.set_raw_data_sensor(raw_data_sensor))
 
-    readout_success_sensor = await binary_sensor.new_binary_sensor(config.get(CONF_READOUT_SUCCESS_SENSOR))
-    cg.add(var.set_readout_success_sensor(readout_success_sensor))
+    consecutive_errors_sensor = await sensor.new_sensor(config.get(CONF_CONSECUTIVE_ERRORS_SENSOR))
+    cg.add(var.set_consecutive_errors_sensor(consecutive_errors_sensor))
 
     cg.add(var.set_consecutive_errors_limit(config[CONF_CONSECUTIVE_ERRORS_LIMIT]))

--- a/components/qalcosonicnfc/__init__.py
+++ b/components/qalcosonicnfc/__init__.py
@@ -85,7 +85,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_CONSECUTIVE_ERRORS_SENSOR, default={ CONF_NAME: "Consecutive Errors",}): sensor.sensor_schema(
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ).extend({cv.Optional("disabled_by_default", default=True): cv.boolean}),
+            ),
             cv.Optional(CONF_CONSECUTIVE_ERRORS_LIMIT, default=5): cv.uint8_t,
             cv.Required(CONF_PN5180_MOSI_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_PN5180_MISO_PIN): pins.gpio_output_pin_schema,

--- a/components/qalcosonicnfc/__init__.py
+++ b/components/qalcosonicnfc/__init__.py
@@ -1,12 +1,12 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
-from esphome.components import sensor, text_sensor#, spi
+from esphome.components import sensor, text_sensor, binary_sensor#, spi
 from esphome.const import CONF_ID, CONF_NAME, CONF_PROTOCOL, CONF_UPDATE_INTERVAL, UNIT_CUBIC_METER, UNIT_CUBIC_METER_PER_HOUR, UNIT_CELSIUS, UNIT_PERCENT, ICON_WATER, ICON_THERMOMETER, ICON_BATTERY, STATE_CLASS_TOTAL_INCREASING, STATE_CLASS_MEASUREMENT, DEVICE_CLASS_WATER, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_BATTERY
 
 CODEOWNERS = ["@dbmaxpayne"]
 
-AUTO_LOAD = ["sensor", "text_sensor", "spi"]
+AUTO_LOAD = ["sensor", "text_sensor", "binary_sensor", "spi"]
 
 DEPENDENCIES = ["network"]
 
@@ -28,6 +28,8 @@ CONF_EXTERNAL_TEMPERATURE_SENSOR = "external_temperature_sensor"
 CONF_BATTERY_LEVEL_SENSOR = "battery_level_sensor"
 CONF_TIMEPOINT_SENSOR = "timepoint_sensor"
 CONF_RAW_DATA_SENSOR = "raw_data_sensor"
+CONF_READOUT_SUCCESS_SENSOR = "readout_success_sensor"
+CONF_CONSECUTIVE_ERRORS_LIMIT = "consecutive_errors_limit"
 
 qalcosonicnfc_ns = cg.esphome_ns.namespace("qalcosonicnfc")
 QalcosonicNfc = qalcosonicnfc_ns.class_("QalcosonicNfc", cg.PollingComponent)
@@ -80,6 +82,8 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_BATTERY,),
             cv.Optional(CONF_RAW_DATA_SENSOR, default={ CONF_NAME: "Raw M-BUS Data",}): text_sensor.text_sensor_schema(),
             cv.Optional(CONF_TIMEPOINT_SENSOR, default={ CONF_NAME: "Timepoint",}): text_sensor.text_sensor_schema(),
+            cv.Optional(CONF_READOUT_SUCCESS_SENSOR, default={ CONF_NAME: "Readout Success",}): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_CONSECUTIVE_ERRORS_LIMIT, default=5): cv.uint8_t,
             cv.Required(CONF_PN5180_MOSI_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_PN5180_MISO_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_PN5180_SCK_PIN): pins.gpio_output_pin_schema,
@@ -128,3 +132,8 @@ async def to_code(config):
     
     raw_data_sensor = await text_sensor.new_text_sensor(config.get(CONF_RAW_DATA_SENSOR))
     cg.add(var.set_raw_data_sensor(raw_data_sensor))
+
+    readout_success_sensor = await binary_sensor.new_binary_sensor(config.get(CONF_READOUT_SUCCESS_SENSOR))
+    cg.add(var.set_readout_success_sensor(readout_success_sensor))
+
+    cg.add(var.set_consecutive_errors_limit(config[CONF_CONSECUTIVE_ERRORS_LIMIT]))

--- a/components/qalcosonicnfc/qalcosonicnfc.cpp
+++ b/components/qalcosonicnfc/qalcosonicnfc.cpp
@@ -188,11 +188,13 @@ void QalcosonicNfc::loop() {
 void QalcosonicNfc::update() {
   ESP_LOGD(TAG, "Update cycle has been started");
   
-  if (!this->nfc_->setupRF()) return;
+  if (!this->nfc_->setupRF()) {
+    this->handleReadoutFailed();
+    return;
+  }
   
   if (this->errorFlag) {
-    this->errorCount++;
-    ESP_LOGD(TAG, "Error flag is set. Consecutive errors: %u", this->errorCount);
+    ESP_LOGD(TAG, "Previous cycle failed. Trying to reset PN5180...");
     uint32_t irqStatus = this->nfc_->getIRQStatus();
     this->nfc_->printIRQStatus(irqStatus);
 
@@ -200,15 +202,18 @@ void QalcosonicNfc::update() {
       ESP_LOGI(TAG, "*** Water meter not found or did not reply!");
     }
     
-    if (this->errorCount > 5) publishSensorsAsFailed();
-    
-    if (!this->nfc_->reset()) return;
-    if (!this->nfc_->setupRF()) return;
+    if (!this->nfc_->reset()) {
+      this->handleReadoutFailed();
+      return;
+    }
+    if (!this->nfc_->setupRF()) {
+      this->handleReadoutFailed();
+      return;
+    }
 
     this->errorFlag = false;
   }
   else {
-      this->errorCount = 0;
       this->status_clear_error();
   }
   
@@ -216,7 +221,7 @@ void QalcosonicNfc::update() {
   ISO15693ErrorCode rc = this->nfc_->getInventory(this->meterUid);
   if (ISO15693_EC_OK != rc) {
     ESP_LOGE(TAG, "Error in getInventory: %s", this->nfc_->ISO15693ErrorCodeToStr(rc));
-    this->errorFlag = true;
+    this->handleReadoutFailed();
     this->nfc_->setRF_off();
     return;
   }
@@ -227,18 +232,21 @@ void QalcosonicNfc::update() {
   // If pin V_EH is actually connected to anything has not been verified
   // At least this should save energy consumed by the ST25 chip itself
   if(!this->st25ReadDynConfig(ST25_EH_CTRL_DYN)) {
+    this->handleReadoutFailed();
     this->nfc_->setRF_off();
     return;
   }
   if(~this->readBuffer[1] & ST25_EH_EN || ~this->readBuffer[1] & ST25_EH_ON || ~this->readBuffer[1] & ST25_FIELD_ON || ~this->readBuffer[1] & ST25_VCC_ON) {
       ESP_LOGE(TAG, "ST25: Energy harvesting is disabled or not available!");
       ESP_LOGE(TAG, "ST25: EH_EN=%u, EH_ON=%u, FIELD_ON=%u, VCC_ON=%u", this->readBuffer[1] & ST25_EH_EN, (this->readBuffer[1] & ST25_EH_ON) >> 1, (readBuffer[1] & ST25_FIELD_ON) >> 2, (this->readBuffer[1] & ST25_VCC_ON) >> 3);
+      this->handleReadoutFailed();
       this->nfc_->setRF_off();
       return;
   }
   ESP_LOGD(TAG, "ST25: Energy harvesting state: EH_EN=%u, EH_ON=%u, FIELD_ON=%u, VCC_ON=%u", this->readBuffer[1] & ST25_EH_EN, (this->readBuffer[1] & ST25_EH_ON) >> 1, (readBuffer[1] & ST25_FIELD_ON) >> 2, (this->readBuffer[1] & ST25_VCC_ON) >> 3);
   
   if(!this->st25MailboxEnable()) {
+      this->handleReadoutFailed();
       this->nfc_->setRF_off();
       return;
   }
@@ -249,19 +257,24 @@ void QalcosonicNfc::update() {
    uint8_t commandGetData1[] = {0x10, 0x7B, 0xFE};
    
    if(!issueMeterCommand(commandResetApp, sizeof(commandResetApp)/sizeof(commandResetApp[0]))) {
+      this->handleReadoutFailed();
       this->nfc_->setRF_off();
       return;
     }
    if(!issueMeterCommand(commandGetData1, sizeof(commandGetData1)/sizeof(commandGetData1[0]))) {
+      this->handleReadoutFailed();
       this->nfc_->setRF_off();
       return;
     }
    
    if(!this->validateMbusFrame()) {
+      this->handleReadoutFailed();
       this->nfc_->setRF_off();
       return;
     }
    
+   this->errorCount = 0;
+   this->readout_success_sensor_->publish_state(true);
    this->publishSensors();
    
   
@@ -368,6 +381,16 @@ void QalcosonicNfc::publishSensorsAsFailed() {
     this->battery_level_sensor_->publish_state(NAN);
     //this->raw_data_sensor_->publish_state(NAN);
     this->status_set_error();
+}
+
+void QalcosonicNfc::handleReadoutFailed() {
+    this->errorFlag = true;
+    this->errorCount++;
+    ESP_LOGD(TAG, "Readout failed. Consecutive errors: %u", this->errorCount);
+    this->readout_success_sensor_->publish_state(false);
+    if (this->consecutive_errors_limit_ > 0 && this->errorCount >= this->consecutive_errors_limit_) {
+        this->publishSensorsAsFailed();
+    }
 }
 
 bool QalcosonicNfc::validateMbusFrame() {

--- a/components/qalcosonicnfc/qalcosonicnfc.cpp
+++ b/components/qalcosonicnfc/qalcosonicnfc.cpp
@@ -274,7 +274,7 @@ void QalcosonicNfc::update() {
     }
    
    this->errorCount = 0;
-   this->readout_success_sensor_->publish_state(true);
+   this->consecutive_errors_sensor_->publish_state(0);
    this->publishSensors();
    
   
@@ -387,7 +387,7 @@ void QalcosonicNfc::handleReadoutFailed() {
     this->errorFlag = true;
     this->errorCount++;
     ESP_LOGD(TAG, "Readout failed. Consecutive errors: %u", this->errorCount);
-    this->readout_success_sensor_->publish_state(false);
+    this->consecutive_errors_sensor_->publish_state(this->errorCount);
     if (this->consecutive_errors_limit_ > 0 && this->errorCount >= this->consecutive_errors_limit_) {
         this->publishSensorsAsFailed();
     }

--- a/components/qalcosonicnfc/qalcosonicnfc.h
+++ b/components/qalcosonicnfc/qalcosonicnfc.h
@@ -21,7 +21,6 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
-#include "esphome/components/binary_sensor/binary_sensor.h"
 #include <esphome/core/hal.h>
 #include "PN5180ISO15693.h"
 
@@ -93,7 +92,7 @@ class QalcosonicNfc : public esphome::PollingComponent {
   sensor::Sensor *battery_level_sensor_{nullptr};
   text_sensor::TextSensor *timepoint_sensor_{nullptr};
   text_sensor::TextSensor *raw_data_sensor_{nullptr};
-  binary_sensor::BinarySensor *readout_success_sensor_{nullptr};
+  sensor::Sensor *consecutive_errors_sensor_{nullptr};
   void publishSensors();
   void publishSensorsAsFailed();
   void handleReadoutFailed();
@@ -109,7 +108,7 @@ class QalcosonicNfc : public esphome::PollingComponent {
   void set_battery_level_sensor(sensor::Sensor *battery_level_sensor) { battery_level_sensor_ = battery_level_sensor; }
   void set_timepoint_sensor(text_sensor::TextSensor *timepoint_sensor) { timepoint_sensor_ = timepoint_sensor; }
   void set_raw_data_sensor(text_sensor::TextSensor *raw_data_sensor) { raw_data_sensor_ = raw_data_sensor; }
-  void set_readout_success_sensor(binary_sensor::BinarySensor *readout_success_sensor) { readout_success_sensor_ = readout_success_sensor; }
+  void set_consecutive_errors_sensor(sensor::Sensor *consecutive_errors_sensor) { consecutive_errors_sensor_ = consecutive_errors_sensor; }
   void set_consecutive_errors_limit(uint8_t consecutive_errors_limit) { consecutive_errors_limit_ = consecutive_errors_limit; }
   void setup() override;
   void loop() override;

--- a/components/qalcosonicnfc/qalcosonicnfc.h
+++ b/components/qalcosonicnfc/qalcosonicnfc.h
@@ -21,6 +21,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include <esphome/core/hal.h>
 #include "PN5180ISO15693.h"
 
@@ -69,6 +70,7 @@ class QalcosonicNfc : public esphome::PollingComponent {
   PN5180ISO15693* nfc_;
   bool errorFlag;
   uint8_t errorCount;
+  uint8_t consecutive_errors_limit_{5};
   uint8_t meterUid[8];
   uint8_t *readBuffer; // Buffer for any data that is received
   uint16_t responseLength; // Stores the actual length of the received data
@@ -91,8 +93,10 @@ class QalcosonicNfc : public esphome::PollingComponent {
   sensor::Sensor *battery_level_sensor_{nullptr};
   text_sensor::TextSensor *timepoint_sensor_{nullptr};
   text_sensor::TextSensor *raw_data_sensor_{nullptr};
+  binary_sensor::BinarySensor *readout_success_sensor_{nullptr};
   void publishSensors();
   void publishSensorsAsFailed();
+  void handleReadoutFailed();
 
  public:
   QalcosonicNfc(GPIOPin *mosi, GPIOPin *miso, GPIOPin *sck, GPIOPin *nss, GPIOPin *busy, GPIOPin *rst);
@@ -105,6 +109,8 @@ class QalcosonicNfc : public esphome::PollingComponent {
   void set_battery_level_sensor(sensor::Sensor *battery_level_sensor) { battery_level_sensor_ = battery_level_sensor; }
   void set_timepoint_sensor(text_sensor::TextSensor *timepoint_sensor) { timepoint_sensor_ = timepoint_sensor; }
   void set_raw_data_sensor(text_sensor::TextSensor *raw_data_sensor) { raw_data_sensor_ = raw_data_sensor; }
+  void set_readout_success_sensor(binary_sensor::BinarySensor *readout_success_sensor) { readout_success_sensor_ = readout_success_sensor; }
+  void set_consecutive_errors_limit(uint8_t consecutive_errors_limit) { consecutive_errors_limit_ = consecutive_errors_limit; }
   void setup() override;
   void loop() override;
   void update() override;


### PR DESCRIPTION
This PR improves the robustness and visibility of the NFC readout process with three key changes:

- **`consecutive_errors_sensor`**: Added a new numeric sensor that tracks failed readout attempts. It resets to `0` on any success and increments on each failure, providing a clear "heartbeat" of the connection quality.
- **Configurable `consecutive_errors_limit`**: Users can now define exactly how many consecutive failures are allowed (default: `5`) before the main sensors (Usage, Flow, etc.) are marked as unavailable (`NAN`). Setting this to `0` prevents the sensors from ever flipping to `NAN`.
- **Immediate Error Logic**: Refactored the error handler so that sensors flip to `NAN` the moment the limit is reached. Previously, the component waited for the start of the *next* update cycle to check the previous failure state, causing an unnecessary delay.

**Note:** The `consecutive_errors_sensor` can exceed the `consecutive_errors_limit`, as the limit only defines the threshold for the `NAN` state, while the sensor continues to track the total count of consecutive failures for troubleshooting purposes.

Please let me know what you think about these changes 🙂