### PR TITLE
Drop SPIComponent::set_component_source call (removed in ESPHome 2026.4.0)

### DIFF
--- a/components/qalcosonicnfc/PN5180.cpp
+++ b/components/qalcosonicnfc/PN5180.cpp
@@ -74,7 +74,6 @@ void PN5180::begin() {
   SPIComponent_ = new spi::SPIComponent();
   SPIDevice_    = new spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
                                      spi::DATA_RATE_5MHZ>;
-  SPIComponent_->set_component_source(LOG_STR("spi"));
   SPIComponent_->set_clk(SCK_);
   SPIComponent_->set_miso(MISO_);
   SPIComponent_->set_mosi(MOSI_);


### PR DESCRIPTION
## Summary

Restores compilation against **ESPHome 2026.4.0**, which currently fails with:

```
src/esphome/components/qalcosonicnfc/PN5180.cpp:77:18: error:
  'class esphome::spi::SPIComponent' has no member named 'set_component_source';
  did you mean 'set_component_source_'?
```

Fixes #21.

## Root cause

Upstream ESPHome PR [esphome/esphome#15103](https://github.com/esphome/esphome/pull/15103) ("[core] Shrink Component from 12 to 8 bytes per instance", merged 2026-03-29) replaced the per-instance component-source string pointer with a table-indexed `uint8_t`. The public `set_component_source(const LogString*)` setter was removed; what remains is the protected `set_component_source_(uint8_t index)`, which is populated by ESPHome's build-time component registration and cannot be called from an external component.

## Change

Drop the single offending call in `PN5180::begin()`:

```diff
-  SPIComponent_->set_component_source(LOG_STR("spi"));
```

That field was only used as a log-prefix label for the dynamically-allocated `SPIComponent`. The already-configured `set_interface_name("SPI2_HOST")` still provides a human-readable identifier in `dump_config`, and the SPI transfers themselves are unaffected.

No other files are touched; YAML configuration is unchanged.

## Test plan

- [x] `esphome compile` succeeds against ESPHome 2026.4.0 (previously failed at `PN5180.cpp.o`).
- [x] Firmware flashes via OTA to an ESP32 + PN5180 + Qalcosonic setup and boots cleanly; the `PN5180`, `PN5180ISO15693` and `qalcosonicnfc` components register and log as before.
- [x] Reviewer sanity-check on their own hardware.

## Note on the `mark_failed` deprecation warnings

The build against 2026.4.0 also emits `mark_failed(const char*)` deprecation warnings in `qalcosonicnfc.cpp` (which will become hard errors in ESPHome 2026.6.0). Those are already addressed in #11, so they're intentionally left out of this PR to keep the diff focused. Merging #11 alongside this should make the component future-proof against 2026.6.0 as well.