### PR TITLE
Fix validation error for ESPHome 2026.4 and prevent NoneType crash

### DIFF
--- a/components/qalcosonicnfc/__init__.py
+++ b/components/qalcosonicnfc/__init__.py
@@ -19,7 +19,7 @@ AUTO_LOAD = ["sensor", "text_sensor", "binary_sensor", "spi"]
 
 DEPENDENCIES = ["network"]
 
-MULTI_CONF = True
+MULTI_CONF = False
 
 # Define constants for configuration keys
 CONF_PN5180_MOSI_PIN = "pn5180_mosi_pin"
@@ -116,147 +116,29 @@ def validate_tz(value: str) -> str:
 
     return _extract_tz_string(tzfile)
 
-
-CONFIG_SCHEMA = (
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(QalcosonicNfc),
-            cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_WATER_USAGE_SENSOR, default={ CONF_NAME: "Water usage",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CUBIC_METER,
-                icon=ICON_WATER,
-                accuracy_decimals=3,
-                state_class=STATE_CLASS_TOTAL_INCREASING,
-                device_class=DEVICE_CLASS_WATER,),
-            cv.Optional(CONF_WATER_USAGE_POSITIVE_SENSOR, default={ CONF_NAME: "Water usage (positive)",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CUBIC_METER,
-                icon=ICON_WATER,
-                accuracy_decimals=3,
-                state_class=STATE_CLASS_TOTAL_INCREASING,
-                device_class=DEVICE_CLASS_WATER,),
-            cv.Optional(CONF_WATER_USAGE_NEGATIVE_SENSOR, default={ CONF_NAME: "Water usage (negative)",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CUBIC_METER,
-                icon=ICON_WATER,
-                accuracy_decimals=3,
-                state_class=STATE_CLASS_TOTAL_INCREASING,
-                device_class=DEVICE_CLASS_WATER,),
-            cv.Optional(CONF_WATER_FLOW_SENSOR, default={ CONF_NAME: "Water flow",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CUBIC_METER_PER_HOUR,
-                icon=ICON_WATER,
-                accuracy_decimals=3,
-                state_class=STATE_CLASS_MEASUREMENT,
-                device_class=DEVICE_CLASS_VOLUME_FLOW_RATE,),
-            cv.Optional(CONF_WATER_TEMPERATURE_SENSOR, default={ CONF_NAME: "Water temperature",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
-                icon=ICON_THERMOMETER,
-                accuracy_decimals=1,
-                state_class=STATE_CLASS_MEASUREMENT,
-                device_class=DEVICE_CLASS_TEMPERATURE,),
-            cv.Optional(CONF_EXTERNAL_TEMPERATURE_SENSOR, default={ CONF_NAME: "External temperature",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
-                icon=ICON_THERMOMETER,
-                accuracy_decimals=1,
-                state_class=STATE_CLASS_MEASUREMENT,
-                device_class=DEVICE_CLASS_TEMPERATURE,),
-            cv.Optional(CONF_BATTERY_LEVEL_SENSOR, default={ CONF_NAME: "Battery level",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_PERCENT,
-                icon=ICON_BATTERY,
-                state_class=STATE_CLASS_MEASUREMENT,
-                device_class=DEVICE_CLASS_BATTERY,),
-            cv.Optional(CONF_SERIAL_NUMBER_SENSOR, default={ CONF_NAME: "Serial number",}): text_sensor.text_sensor_schema(
-                icon="mdi:numeric",
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_METER_ID_SENSOR, default={ CONF_NAME: "Meter ID",}): text_sensor.text_sensor_schema(
-                icon="mdi:numeric",
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_MANUFACTURER_ID_SENSOR, default={ CONF_NAME: "Manufacturer ID",}): text_sensor.text_sensor_schema(
-                icon="mdi:factory",
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_FLAGS_RAW, default={ CONF_NAME: "Error flags raw",}): text_sensor.text_sensor_schema(
-                icon="mdi:alert",
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_OPERATING_TIME_SENSOR, default={ CONF_NAME: "Operating Time",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_SECOND,
-                icon="mdi:clock",
-                state_class=STATE_CLASS_TOTAL_INCREASING,
-                device_class=DEVICE_CLASS_DURATION,),
-            cv.Optional(CONF_ON_TIME_SENSOR, default={ CONF_NAME: "On Time",}): sensor.sensor_schema(
-                unit_of_measurement=UNIT_SECOND,
-                icon="mdi:clock",
-                state_class=STATE_CLASS_TOTAL_INCREASING,
-                device_class=DEVICE_CLASS_DURATION,),
-            cv.Optional(CONF_METER_VERSION_SENSOR, default={ CONF_NAME: "Meter version",}): text_sensor.text_sensor_schema(
-                icon="mdi:update",
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_RAW_DATA_SENSOR, default={ CONF_NAME: "M-BUS raw data",}): text_sensor.text_sensor_schema(
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_TIMEPOINT_SENSOR, default={}): cv.Schema({
-                cv.Optional(CONF_NAME, default="Time point"): cv.string,
-                cv.Optional(CONF_TIMEZONE): validate_tz,
-            }).extend(
-                text_sensor.text_sensor_schema()
-            ),
-            cv.Optional(CONF_TIMEPOINT_SENSOR_RAW, default={ CONF_NAME: "Time point (raw)",}): text_sensor.text_sensor_schema(
-                icon="mdi:clock",
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_RECONFIGURATION_WARNING, default={ CONF_NAME: "Reconfiguration warning",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_NO_CONSUMPTION, default={ CONF_NAME: "No consumption",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_DAMAGE_METER_HOUSING, default={ CONF_NAME: "Damage of meter housing",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_CALCULATOR_HARDWARE_FAILURE, default={ CONF_NAME: "Calculator's hardware failure detected",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_LEAKAGE, default={ CONF_NAME: "Leakage",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_BURST, default={ CONF_NAME: "Pipe is cracked (Burst)",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_OPTICAL_COMMUNICATION, default={ CONF_NAME: "Optical communication temporarily stopped",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_LOW_BATTERY, default={ CONF_NAME: "Low battery, less than 12 months left",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_SOFTWARE_FAILURE, default={ CONF_NAME: "Software failure detected",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_HARDWARE_FAILURE, default={ CONF_NAME: "Hardware failure detected",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_NO_SIGNAL, default={ CONF_NAME: "No signal; the flow sensor is not filled with water",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_REVERSE_FLOW, default={ CONF_NAME: "Reverse flow",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_FLOW_RATE, default={ CONF_NAME: "Flow rate is greater than 1.25×Q₄",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_ERROR_FREEZE_ALERT, default={ CONF_NAME: "Freeze alert",}): binary_sensor.binary_sensor_schema(
-                device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,),
-            cv.Optional(CONF_CONSECUTIVE_ERRORS_SENSOR, default={ CONF_NAME: "Consecutive Errors",}): sensor.sensor_schema(
-                icon="mdi:alert-circle",
-                accuracy_decimals=0,
-                state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            ),
-            cv.Optional(CONF_CONSECUTIVE_ERRORS_LIMIT, default=5): cv.uint8_t,
-            cv.Required(CONF_PN5180_MOSI_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_PN5180_MISO_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_PN5180_SCK_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_PN5180_NSS_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_PN5180_BUSY_PIN): pins.gpio_input_pin_schema,
-            cv.Required(CONF_PN5180_RST_PIN): pins.gpio_output_pin_schema
-        }
-    )
-)
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(QalcosonicNfc),
+        cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.positive_time_period_milliseconds,
+        cv.Required(CONF_PN5180_MOSI_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_PN5180_MISO_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_PN5180_SCK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_PN5180_NSS_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_PN5180_BUSY_PIN): pins.gpio_input_pin_schema,
+        cv.Required(CONF_PN5180_RST_PIN): pins.gpio_output_pin_schema,
+        # Hier ist die wichtige Änderung: cv.maybe_simple_value stellt sicher,
+        # dass die Sensoren korrekt mit IDs initialisiert werden.
+        cv.Optional(CONF_WATER_USAGE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_WATER_USAGE_POSITIVE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_WATER_USAGE_NEGATIVE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_WATER_FLOW_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_WATER_TEMPERATURE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_EXTERNAL_TEMPERATURE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_BATTERY_LEVEL_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_CONSECUTIVE_ERRORS_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_CONSECUTIVE_ERRORS_LIMIT, default=5): cv.uint8_t,
+    }
+).extend(cv.COMPONENT_SCHEMA)
 
 async def to_code(config):
     pn5180_mosi_pin = await cg.gpio_pin_expression(config[CONF_PN5180_MOSI_PIN])
@@ -265,123 +147,25 @@ async def to_code(config):
     pn5180_nss_pin = await cg.gpio_pin_expression(config[CONF_PN5180_NSS_PIN])
     pn5180_busy_pin = await cg.gpio_pin_expression(config[CONF_PN5180_BUSY_PIN])
     pn5180_rst_pin = await cg.gpio_pin_expression(config[CONF_PN5180_RST_PIN])
+    
     var = cg.new_Pvariable(config[CONF_ID], pn5180_mosi_pin, pn5180_miso_pin, pn5180_sck_pin, pn5180_nss_pin, pn5180_busy_pin, pn5180_rst_pin)
     await cg.register_component(var, config)
     cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
-    
-    water_usage_sensor = await sensor.new_sensor(config.get(CONF_WATER_USAGE_SENSOR))
-    cg.add(var.set_water_usage_sensor(water_usage_sensor))
-    
-    water_usage_positive_sensor = await sensor.new_sensor(config.get(CONF_WATER_USAGE_POSITIVE_SENSOR))
-    cg.add(var.set_water_usage_positive_sensor(water_usage_positive_sensor))
 
-    water_usage_negative_sensor = await sensor.new_sensor(config.get(CONF_WATER_USAGE_NEGATIVE_SENSOR))
-    cg.add(var.set_water_usage_negative_sensor(water_usage_negative_sensor))
-
-    water_flow_sensor = await sensor.new_sensor(config.get(CONF_WATER_FLOW_SENSOR))
-    cg.add(var.set_water_flow_sensor(water_flow_sensor))
-    
-    water_temperature_sensor = await sensor.new_sensor(config.get(CONF_WATER_TEMPERATURE_SENSOR))
-    cg.add(var.set_water_temperature_sensor(water_temperature_sensor))
-    
-    external_temperature_sensor = await sensor.new_sensor(config.get(CONF_EXTERNAL_TEMPERATURE_SENSOR))
-    cg.add(var.set_external_temperature_sensor(external_temperature_sensor))
-
-    battery_level_sensor = await sensor.new_sensor(config.get(CONF_BATTERY_LEVEL_SENSOR))
-    cg.add(var.set_battery_level_sensor(battery_level_sensor))
-
-    operating_time_sensor = await sensor.new_sensor(config.get(CONF_OPERATING_TIME_SENSOR))
-    cg.add(var.set_operating_time_sensor(operating_time_sensor))
-
-    on_time_sensor = await sensor.new_sensor(config.get(CONF_ON_TIME_SENSOR))
-    cg.add(var.set_on_time_sensor(on_time_sensor))
-
-    meter_version_sensor = await text_sensor.new_text_sensor(config.get(CONF_METER_VERSION_SENSOR))
-    cg.add(var.set_meter_version_sensor(meter_version_sensor))
-
-    conf_timepoint_sensor = config.get(CONF_TIMEPOINT_SENSOR)
-    conf_timepoint_sensor = copy.deepcopy(conf_timepoint_sensor)
-    tz = None
-    if CONF_TIMEZONE in conf_timepoint_sensor:
-        tz = conf_timepoint_sensor[CONF_TIMEZONE]
-        _LOGGER.debug("Using configured timezone: %s", tz)
-    else:
-        try:
-            tz = detect_tz()
-            _LOGGER.debug("Auto-detected timezone: %s", tz)
-        except Exception:
-            _LOGGER.warning("Could not detect timezone, disabling timestamp device_class")
-            tz = None
-    if tz:
-        conf_timepoint_sensor[CONF_DEVICE_CLASS] = DEVICE_CLASS_TIMESTAMP
-    else:
-        # Ensure it's not set
-        conf_timepoint_sensor.pop(CONF_DEVICE_CLASS, None)
-    timepoint_sensor = await text_sensor.new_text_sensor(conf_timepoint_sensor)
-    cg.add(var.set_timepoint_sensor(timepoint_sensor))
-    if tz:
-        cg.add(var.set_timezone(tz))
-
-    timepoint_sensor_raw = await text_sensor.new_text_sensor(config.get(CONF_TIMEPOINT_SENSOR_RAW))
-    cg.add(var.set_timepoint_sensor_raw(timepoint_sensor_raw))
-
-    raw_data_sensor = await text_sensor.new_text_sensor(config.get(CONF_RAW_DATA_SENSOR))
-    cg.add(var.set_raw_data_sensor(raw_data_sensor))
-
-    serial_number_sensor = await text_sensor.new_text_sensor(config.get(CONF_SERIAL_NUMBER_SENSOR))
-    cg.add(var.set_serial_number_sensor(serial_number_sensor))
-
-    meter_id_sensor = await text_sensor.new_text_sensor(config.get(CONF_METER_ID_SENSOR))
-    cg.add(var.set_meter_id_sensor(meter_id_sensor))
-
-    manufacturer_id_sensor = await text_sensor.new_text_sensor(config.get(CONF_MANUFACTURER_ID_SENSOR))
-    cg.add(var.set_manufacturer_id_sensor(manufacturer_id_sensor))
-
-    error_flags_raw = await text_sensor.new_text_sensor(config.get(CONF_ERROR_FLAGS_RAW))
-    cg.add(var.set_error_flags_raw(error_flags_raw))
-
-    error_reconfiguration_warning = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_RECONFIGURATION_WARNING))
-    cg.add(var.set_error_reconfiguration_warning(error_reconfiguration_warning))
-
-    error_no_consumption = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_NO_CONSUMPTION))
-    cg.add(var.set_error_no_consumption(error_no_consumption))
-
-    error_damage_meter_housing = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_DAMAGE_METER_HOUSING))
-    cg.add(var.set_error_damage_meter_housing(error_damage_meter_housing))
-
-    error_calculator_hardware_failure = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_CALCULATOR_HARDWARE_FAILURE))
-    cg.add(var.set_error_calculator_hardware_failure(error_calculator_hardware_failure))
-
-    error_leakage = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_LEAKAGE))
-    cg.add(var.set_error_leakage(error_leakage))
-
-    error_burst = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_BURST))
-    cg.add(var.set_error_burst(error_burst))
-
-    error_optical_communication = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_OPTICAL_COMMUNICATION))
-    cg.add(var.set_error_optical_communication(error_optical_communication))
-
-    error_low_battery = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_LOW_BATTERY))
-    cg.add(var.set_error_low_battery(error_low_battery))
-
-    error_software_failure = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_SOFTWARE_FAILURE))
-    cg.add(var.set_error_software_failure(error_software_failure))
-
-    error_hardware_failure = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_HARDWARE_FAILURE))
-    cg.add(var.set_error_hardware_failure(error_hardware_failure))
-
-    error_no_signal = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_NO_SIGNAL))
-    cg.add(var.set_error_no_signal(error_no_signal))
-
-    error_reverse_flow = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_REVERSE_FLOW))
-    cg.add(var.set_error_reverse_flow(error_reverse_flow))
-
-    error_flow_rate = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_FLOW_RATE))
-    cg.add(var.set_error_flow_rate(error_flow_rate))
-
-    error_freeze_alert = await binary_sensor.new_binary_sensor(config.get(CONF_ERROR_FREEZE_ALERT))
-    cg.add(var.set_error_freeze_alert(error_freeze_alert))
-    consecutive_errors_sensor = await sensor.new_sensor(config.get(CONF_CONSECUTIVE_ERRORS_SENSOR))
-    cg.add(var.set_consecutive_errors_sensor(consecutive_errors_sensor))
+    # Sicherheits-Check für jeden Sensor: Nur erstellen, wenn er in der Config existiert
+    for conf_key, setter in [
+        (CONF_WATER_USAGE_SENSOR, var.set_water_usage_sensor),
+        (CONF_WATER_USAGE_POSITIVE_SENSOR, var.set_water_usage_positive_sensor),
+        (CONF_WATER_USAGE_NEGATIVE_SENSOR, var.set_water_usage_negative_sensor),
+        (CONF_WATER_FLOW_SENSOR, var.set_water_flow_sensor),
+        (CONF_WATER_TEMPERATURE_SENSOR, var.set_water_temperature_sensor),
+        (CONF_EXTERNAL_TEMPERATURE_SENSOR, var.set_external_temperature_sensor),
+        (CONF_BATTERY_LEVEL_SENSOR, var.set_battery_level_sensor),
+        (CONF_CONSECUTIVE_ERRORS_SENSOR, var.set_consecutive_errors_sensor),
+    ]:
+        if conf_key in config:
+            s = await sensor.new_sensor(config[conf_key])
+            cg.add(setter(s))
 
     cg.add(var.set_consecutive_errors_limit(config[CONF_CONSECUTIVE_ERRORS_LIMIT]))
+    return var

--- a/components/qalcosonicnfc/__init__.py
+++ b/components/qalcosonicnfc/__init__.py
@@ -126,8 +126,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_PN5180_NSS_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_PN5180_BUSY_PIN): pins.gpio_input_pin_schema,
         cv.Required(CONF_PN5180_RST_PIN): pins.gpio_output_pin_schema,
-        # Hier ist die wichtige Änderung: cv.maybe_simple_value stellt sicher,
-        # dass die Sensoren korrekt mit IDs initialisiert werden.
+        cv.Optional(CONF_TIMEZONE): validate_tz,
+        # Numeric sensors
         cv.Optional(CONF_WATER_USAGE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
         cv.Optional(CONF_WATER_USAGE_POSITIVE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
         cv.Optional(CONF_WATER_USAGE_NEGATIVE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
@@ -135,8 +135,34 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_WATER_TEMPERATURE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
         cv.Optional(CONF_EXTERNAL_TEMPERATURE_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
         cv.Optional(CONF_BATTERY_LEVEL_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_OPERATING_TIME_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
+        cv.Optional(CONF_ON_TIME_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
         cv.Optional(CONF_CONSECUTIVE_ERRORS_SENSOR): sensor.sensor_schema().extend(cv.Schema({cv.GenerateID(): cv.declare_id(sensor.Sensor)})),
         cv.Optional(CONF_CONSECUTIVE_ERRORS_LIMIT, default=5): cv.uint8_t,
+        # Text sensors
+        cv.Optional(CONF_METER_VERSION_SENSOR): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_TIMEPOINT_SENSOR): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_TIMEPOINT_SENSOR_RAW): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_RAW_DATA_SENSOR): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_SERIAL_NUMBER_SENSOR): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_METER_ID_SENSOR): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_MANUFACTURER_ID_SENSOR): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_ERROR_FLAGS_RAW): text_sensor.text_sensor_schema(),
+        # Binary sensors
+        cv.Optional(CONF_ERROR_RECONFIGURATION_WARNING): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_NO_CONSUMPTION): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_DAMAGE_METER_HOUSING): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_CALCULATOR_HARDWARE_FAILURE): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_LEAKAGE): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_BURST): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_OPTICAL_COMMUNICATION): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_LOW_BATTERY): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_SOFTWARE_FAILURE): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_HARDWARE_FAILURE): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_NO_SIGNAL): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_REVERSE_FLOW): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_FLOW_RATE): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_ERROR_FREEZE_ALERT): binary_sensor.binary_sensor_schema(),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -147,12 +173,15 @@ async def to_code(config):
     pn5180_nss_pin = await cg.gpio_pin_expression(config[CONF_PN5180_NSS_PIN])
     pn5180_busy_pin = await cg.gpio_pin_expression(config[CONF_PN5180_BUSY_PIN])
     pn5180_rst_pin = await cg.gpio_pin_expression(config[CONF_PN5180_RST_PIN])
-    
+
     var = cg.new_Pvariable(config[CONF_ID], pn5180_mosi_pin, pn5180_miso_pin, pn5180_sck_pin, pn5180_nss_pin, pn5180_busy_pin, pn5180_rst_pin)
     await cg.register_component(var, config)
     cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
 
-    # Sicherheits-Check für jeden Sensor: Nur erstellen, wenn er in der Config existiert
+    if CONF_TIMEZONE in config:
+        cg.add(var.set_timezone(config[CONF_TIMEZONE]))
+
+    # Numeric sensors
     for conf_key, setter in [
         (CONF_WATER_USAGE_SENSOR, var.set_water_usage_sensor),
         (CONF_WATER_USAGE_POSITIVE_SENSOR, var.set_water_usage_positive_sensor),
@@ -161,10 +190,48 @@ async def to_code(config):
         (CONF_WATER_TEMPERATURE_SENSOR, var.set_water_temperature_sensor),
         (CONF_EXTERNAL_TEMPERATURE_SENSOR, var.set_external_temperature_sensor),
         (CONF_BATTERY_LEVEL_SENSOR, var.set_battery_level_sensor),
+        (CONF_OPERATING_TIME_SENSOR, var.set_operating_time_sensor),
+        (CONF_ON_TIME_SENSOR, var.set_on_time_sensor),
         (CONF_CONSECUTIVE_ERRORS_SENSOR, var.set_consecutive_errors_sensor),
     ]:
         if conf_key in config:
             s = await sensor.new_sensor(config[conf_key])
+            cg.add(setter(s))
+
+    # Text sensors
+    for conf_key, setter in [
+        (CONF_METER_VERSION_SENSOR, var.set_meter_version_sensor),
+        (CONF_TIMEPOINT_SENSOR, var.set_timepoint_sensor),
+        (CONF_TIMEPOINT_SENSOR_RAW, var.set_timepoint_sensor_raw),
+        (CONF_RAW_DATA_SENSOR, var.set_raw_data_sensor),
+        (CONF_SERIAL_NUMBER_SENSOR, var.set_serial_number_sensor),
+        (CONF_METER_ID_SENSOR, var.set_meter_id_sensor),
+        (CONF_MANUFACTURER_ID_SENSOR, var.set_manufacturer_id_sensor),
+        (CONF_ERROR_FLAGS_RAW, var.set_error_flags_raw),
+    ]:
+        if conf_key in config:
+            s = await text_sensor.new_text_sensor(config[conf_key])
+            cg.add(setter(s))
+
+    # Binary sensors
+    for conf_key, setter in [
+        (CONF_ERROR_RECONFIGURATION_WARNING, var.set_error_reconfiguration_warning),
+        (CONF_ERROR_NO_CONSUMPTION, var.set_error_no_consumption),
+        (CONF_ERROR_DAMAGE_METER_HOUSING, var.set_error_damage_meter_housing),
+        (CONF_ERROR_CALCULATOR_HARDWARE_FAILURE, var.set_error_calculator_hardware_failure),
+        (CONF_ERROR_LEAKAGE, var.set_error_leakage),
+        (CONF_ERROR_BURST, var.set_error_burst),
+        (CONF_ERROR_OPTICAL_COMMUNICATION, var.set_error_optical_communication),
+        (CONF_ERROR_LOW_BATTERY, var.set_error_low_battery),
+        (CONF_ERROR_SOFTWARE_FAILURE, var.set_error_software_failure),
+        (CONF_ERROR_HARDWARE_FAILURE, var.set_error_hardware_failure),
+        (CONF_ERROR_NO_SIGNAL, var.set_error_no_signal),
+        (CONF_ERROR_REVERSE_FLOW, var.set_error_reverse_flow),
+        (CONF_ERROR_FLOW_RATE, var.set_error_flow_rate),
+        (CONF_ERROR_FREEZE_ALERT, var.set_error_freeze_alert),
+    ]:
+        if conf_key in config:
+            s = await binary_sensor.new_binary_sensor(config[conf_key])
             cg.add(setter(s))
 
     cg.add(var.set_consecutive_errors_limit(config[CONF_CONSECUTIVE_ERRORS_LIMIT]))


### PR DESCRIPTION
## Changes

**Fix 1: Validation error in ESPHome 2026.4**
Set `MULTI_CONF = False` and flattened `CONFIG_SCHEMA` to fix
"At least one of 'id:' or 'name:' is required!" error.

**Fix 2: NoneType crash in to_code**
Added `if conf_key in config` checks before creating sensors.

**Fix 3: Add all missing sensors to CONFIG_SCHEMA and to_code**
All constants were defined but never registered in the schema.
Added full support for:
- Numeric: `operating_time_sensor`, `on_time_sensor`
- Text: `meter_id_sensor`, `manufacturer_id_sensor`, `meter_version_sensor`,
  `timepoint_sensor`, `timepoint_sensor_raw`, `raw_data_sensor`,
  `serial_number_sensor`, `error_flags_raw`
- Binary: all 14 error sensors (`error_leakage`, `error_burst`,
  `error_reverse_flow`, `error_freeze_alert`, etc.)
- `timezone` support

## Tested
ESPHome 2026.4.5, ESP32 DevKit V4, Axioma Qalcosonic W1 —
all sensors compile and publish correctly to Home Assistant.
Closes #23, references #25