### PR TITLE
Fix recent build warnings

### DIFF
--- a/components/qalcosonicnfc/PN5180.cpp
+++ b/components/qalcosonicnfc/PN5180.cpp
@@ -182,7 +182,7 @@ bool PN5180::readRegister(uint8_t reg, uint32_t *value) {
       ESP_LOGE(TAG, "Reading register %02X failed", reg);
       return false;
   }
-  ESP_LOGD(TAG, "Register value=%02X", *value);
+  ESP_LOGD(TAG, "Register value=%02lX", *value);
 
   return true;
 }
@@ -510,7 +510,7 @@ uint32_t PN5180::getIRQStatus() {
 }
 
 bool PN5180::clearIRQStatus(uint32_t irqMask) {
-  ESP_LOGD(TAG, "Clear IRQ-Status with mask=0x%02X:", irqMask);
+  ESP_LOGD(TAG, "Clear IRQ-Status with mask=0x%02lX:", irqMask);
 
   return writeRegister(IRQ_CLEAR, irqMask);
 }
@@ -538,7 +538,7 @@ void PN5180::printIRQStatus(uint32_t irqStatus) {
   if (irqStatus & (1<<18)) readableIRQStatus += "HV_ERROR ";
   if (irqStatus & (1<<19)) readableIRQStatus += "LPCD ";
   
-  ESP_LOGD(TAG, "IRQ-Status 0x%08X: [%s]", irqStatus, readableIRQStatus.c_str());
+  ESP_LOGD(TAG, "IRQ-Status 0x%08lX: [%s]", irqStatus, readableIRQStatus.c_str());
 }
 
 

--- a/components/qalcosonicnfc/PN5180ISO15693.cpp
+++ b/components/qalcosonicnfc/PN5180ISO15693.cpp
@@ -378,7 +378,7 @@ ISO15693ErrorCode PN5180ISO15693::issueISO15693Command(uint8_t *cmd, uint8_t cmd
   readRegister(RX_STATUS, &rxStatus);
 
   uint16_t len = (uint16_t)(rxStatus & 0x000001ff);
-  ESP_LOGD(TAG, "RX-Status=0x%02X, len=%u", rxStatus, len);
+  ESP_LOGD(TAG, "RX-Status=0x%02lX, len=%u", rxStatus, len);
 
  *resultPtr = readData(len);
   if (0L == *resultPtr) {
@@ -435,7 +435,7 @@ ISO15693ErrorCode PN5180ISO15693::issueISO15693Command(uint8_t *cmd, uint8_t cmd
   readRegister(RX_STATUS, &rxStatus);
   
   *responseLength = (uint16_t)(rxStatus & 0x000001ff);
-  ESP_LOGD(TAG, "RX-Status=0x%02X, len=%u", rxStatus, *responseLength);
+  ESP_LOGD(TAG, "RX-Status=0x%02lX, len=%u", rxStatus, *responseLength);
 
  *resultPtr = readData(*responseLength);
   if (0L == *resultPtr) {

--- a/components/qalcosonicnfc/qalcosonicnfc.cpp
+++ b/components/qalcosonicnfc/qalcosonicnfc.cpp
@@ -349,8 +349,8 @@ void QalcosonicNfc::publishSensors() {
                          (readBuffer[start_idx + 9] >> 4) * 100000 + (readBuffer[start_idx + 9] & 0x0F) * 10000 +
                          (readBuffer[start_idx + 8] >> 4) * 1000 + (readBuffer[start_idx + 8] & 0x0F) * 100 +
                          (readBuffer[start_idx + 7] >> 4) * 10 + (readBuffer[start_idx + 7] & 0x0F);
-    char str_id_number[9];
-    snprintf(str_id_number, sizeof(str_id_number), "%08u", id_number);
+    char str_id_number[11];
+    snprintf(str_id_number, sizeof(str_id_number), "%08lu", id_number);
     ESP_LOGI(TAG, "ID Number: %s", str_id_number);
     if(this->meter_id_sensor_) this->meter_id_sensor_->publish_state(str_id_number);
 
@@ -441,21 +441,21 @@ void QalcosonicNfc::publishSensors() {
         switch (vif << 8 | vife) {
             case 0x1300: {
                 int32_t waterUsage = int32_t(buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0]);
-                ESP_LOGI(TAG, "Water Usage: %iL / %1.3fm³", waterUsage, waterUsage/1000.0f);
+                ESP_LOGI(TAG, "Water Usage: %liL / %1.3fm³", waterUsage, waterUsage/1000.0f);
                 if(this->water_usage_sensor_) this->water_usage_sensor_->publish_state(waterUsage/1000.0f);
                 break;
             }
 
             case 0x933b: {
                 int32_t waterUsage = int32_t(buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0]);
-                ESP_LOGI(TAG, "Water Usage (Only Positive): %iL / %1.3fm³", waterUsage, waterUsage/1000.0f);
+                ESP_LOGI(TAG, "Water Usage (Only Positive): %liL / %1.3fm³", waterUsage, waterUsage/1000.0f);
                 if(this->water_usage_positive_sensor_) this->water_usage_positive_sensor_->publish_state(waterUsage/1000.0f);
                 break;
             }
 
             case 0x933c: {
                 int32_t waterUsage = int32_t(buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0]);
-                ESP_LOGI(TAG, "Water Usage (Only Negative): %iL / %1.3fm³", waterUsage, waterUsage/1000.0f);
+                ESP_LOGI(TAG, "Water Usage (Only Negative): %liL / %1.3fm³", waterUsage, waterUsage/1000.0f);
                 if(this->water_usage_negative_sensor_) this->water_usage_negative_sensor_->publish_state(waterUsage/1000.0f);
                 break;
             }
@@ -486,7 +486,7 @@ void QalcosonicNfc::publishSensors() {
                 int32_t hour = buf[1] & 0x1F;
                 int32_t day = buf[2] & 0x1F;
                 int32_t month = buf[3] & 0x0F;
-                int32_t year = (buf[2] >> 5 | (buf[3] >> 1) & 0xF8) + 2000;
+                int32_t year = ((buf[2] >> 5) | ((buf[3] >> 1) & 0xF8)) + 2000;
                 char str_timepoint[32];
                 if (!this->timezone_.empty()) {
                     setenv("TZ", this->timezone_.c_str(), 1);
@@ -504,7 +504,7 @@ void QalcosonicNfc::publishSensors() {
                     strftime(str_timepoint, sizeof(str_timepoint), "%Y-%m-%dT%H:%M:%S%z", &timeinfo);
                 } else {
                     // fallback if timezone is not set
-                    snprintf(str_timepoint, sizeof(str_timepoint), "%04u-%02u-%02u %02u:%02u", year, month, day, hour, minute);
+                    snprintf(str_timepoint, sizeof(str_timepoint), "%04li-%02li-%02li %02li:%02li", year, month, day, hour, minute);
                 }
                 ESP_LOGI(TAG, "Timepoint: %s", str_timepoint);
                 if(this->timepoint_sensor_) this->timepoint_sensor_->publish_state(str_timepoint);
@@ -512,7 +512,7 @@ void QalcosonicNfc::publishSensors() {
                 // publish the timepoint string as raw data without any date math
                 // may be offset from the current time by one hour because the meter does not switch to/from DST
                 char str_timepoint_raw[17];
-                snprintf(str_timepoint_raw, sizeof(str_timepoint_raw), "%04u-%02u-%02u %02u:%02u", year, month, day, hour, minute);
+                snprintf(str_timepoint_raw, sizeof(str_timepoint_raw), "%04li-%02li-%02li %02li:%02li", year, month, day, hour, minute);
                 ESP_LOGI(TAG, "Timepoint raw: %s", str_timepoint_raw);
                 if(this->timepoint_sensor_raw_) this->timepoint_sensor_raw_->publish_state(str_timepoint_raw);
                 break;
@@ -538,9 +538,9 @@ void QalcosonicNfc::publishSensors() {
                         // fallback if the meter sends it as a standard binary integer
                         serialNumber = uint32_t(buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0]);
                     }
-                    ESP_LOGI(TAG, "Serial Number: %08u", serialNumber);
-                    char str_serial_number[9]; 
-                    snprintf(str_serial_number, sizeof(str_serial_number), "%08u", serialNumber);
+                    ESP_LOGI(TAG, "Serial Number: %08lu", serialNumber);
+                    char str_serial_number[11];
+                    snprintf(str_serial_number, sizeof(str_serial_number), "%08lu", serialNumber);
                     if(this->serial_number_sensor_) this->serial_number_sensor_->publish_state(str_serial_number);
                     break;
                 }
@@ -578,7 +578,7 @@ void QalcosonicNfc::publishSensors() {
             case 0x2400:
                 {
                     uint32_t operatingTimeSec = uint32_t(buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0]);
-                    ESP_LOGI(TAG, "Operating Time: %u seconds (%.1f days)", operatingTimeSec, operatingTimeSec / 86400.0f);
+                    ESP_LOGI(TAG, "Operating Time: %lu seconds (%.1f days)", operatingTimeSec, operatingTimeSec / 86400.0f);
                     if(this->operating_time_sensor_) this->operating_time_sensor_->publish_state(operatingTimeSec);
                     break;
                 }
@@ -586,7 +586,7 @@ void QalcosonicNfc::publishSensors() {
             case 0x2000:
                 {
                     uint32_t onTimeSec = uint32_t(buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0]);
-                    ESP_LOGI(TAG, "On Time: %u seconds (%.1f days)", onTimeSec, onTimeSec / 86400.0f);
+                    ESP_LOGI(TAG, "On Time: %lu seconds (%.1f days)", onTimeSec, onTimeSec / 86400.0f);
                     if(this->on_time_sensor_) this->on_time_sensor_->publish_state(onTimeSec);
                     break;
                 }


### PR DESCRIPTION
Resolve all compiler warnings reported during build for the qalcosonicnfc component:

- `PN5180.cpp` / `PN5180ISO15693.cpp`: change `%02X/%08X` format specifiers to `%02lX/%08lX` to match `uint32_t` arguments (readRegister, clearIRQStatus, printIRQStatus, issueISO15693Command), fixing `-Wformat` warnings.
- `qalcosonicnfc.cpp`: change `%u/%i` specifiers to `%lu/%li` to match `uint32_t/int32_t` arguments in id number, water usage, timepoint, serial number, and operating/on time log statements, fixing `-Wformat` warnings.
- `qalcosonicnfc.cpp`: add explicit parentheses around the year bit-extraction expression to clarify intended |/& operator precedence, fixing a `-Wparentheses` warning.
- `qalcosonicnfc.cpp`: enlarge `str_id_number` and `str_serial_number` buffers from `9` to `11` bytes to safely hold up to 10-digit `uint32_t` values plus the `null` terminator, fixing a `-Wformat-truncation` warning.

No behavioral changes; all fixes are limited to log/format strings and buffer sizes.